### PR TITLE
updating code's with latest changes ...

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "redhat.vscode-yaml"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "editor.formatOnPaste": true,
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "typescript.enablePromptUseWorkspaceTsdk": true,
+    "editor.acceptSuggestionOnCommitCharacter": false
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "lint:check": "eslint . --ext .ts",
         "lint:fix": "eslint . --ext .ts --fix",
         "build": "rimraf ./dist && tsc",
-        "run": "npm run build && node -r source-map-support/register dist/main",
+        "run": "npm run build && node --enable-source-maps dist/main",
         "prepare": "husky"
     },
     "author": "https://github.com/ethan-xd",
@@ -25,7 +25,6 @@
         "husky": "^9.0.11",
         "prettier": "^3.2.5",
         "rimraf": "^5.0.5",
-        "source-map-support": "^0.5.21",
         "typescript": "^5.4.5"
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,7 +70,8 @@
         /* other options that weren't in the template */
         "noPropertyAccessFromIndexSignature": true,
         "noImplicitOverride": true,
-        "exactOptionalPropertyTypes": true
+        "exactOptionalPropertyTypes": true,
+        "moduleDetection": "force",
     },
     "include": ["src/**/*.ts", "*.eslintrc.js"]
 }


### PR DESCRIPTION
# vscode settings:
- `typescript.tsdk` / `typescript.enablePromptUseWorkspaceTsdk` - will prompt the user to use the version of typescript installed in the project instead of whatever random version is bundled with vscode. prevents the possibility of errors in vscode that don't appear in CI & vice versa
- `editor.acceptSuggestionOnCommitCharacter` - prevents this stupid shit where typing certain characters while autocomplete suggestions are present will automatically apply the suggestions
- `extensions.json` - user will be prompted to install extensions for tools that are used in this project (eg. prettier, eslint)

# `package.json`
- removed `source-map-support` since they are now natively supported in node

# `tsconfig.json`
- set `moduleDetection` to `"force"`. without this, it will assume any typescript file that doesn't have any imports or exports means that everything defined in that file is available globally (which is the stupidest fucking thing ever i cant believe thats still the default behavior)